### PR TITLE
Add template delete button

### DIFF
--- a/frontend/src/pages/TemplatesPage.tsx
+++ b/frontend/src/pages/TemplatesPage.tsx
@@ -189,6 +189,20 @@ const TemplatesPage: React.FC = () => {
     }
   };
 
+  const handleDeleteTemplate = async (templateId: string) => {
+    if (!window.confirm('このテンプレートを削除しますか？')) {
+      return;
+    }
+
+    try {
+      await templateApi.delete(templateId);
+      await loadTemplates();
+    } catch (err: any) {
+      console.error('Failed to delete template:', err);
+      setError('テンプレートの削除に失敗しました');
+    }
+  };
+
   const openEditDialog = (template: Template) => {
     setEditDialog(template);
     setFormData({
@@ -361,6 +375,14 @@ const TemplatesPage: React.FC = () => {
                       onClick={() => handleCreateVersion(template.id)}
                     >
                       新バージョン
+                    </Button>
+                    <Button
+                      size="small"
+                      startIcon={<Delete />}
+                      color="error"
+                      onClick={() => handleDeleteTemplate(template.id)}
+                    >
+                      削除
                     </Button>
                   </CardActions>
                 )}


### PR DESCRIPTION
## Summary
- allow deleting templates from UI

## Testing
- `npm --prefix frontend run lint`
- `npm --prefix backend run lint`


------
https://chatgpt.com/codex/tasks/task_e_685d19272720832e965f3efce0aa124a